### PR TITLE
ci: Change `dplv2` option to `dplv1` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ script:
 - npm run docs:build
 deploy:
   provider: pages
-  cleanup: false
   local_dir: docs/.vuepress/dist
   github_token: "$GITHUB_TOKEN"
   keep_history: true
   committer_from_gh: true
+  skip_cleanup: true
   on:
     branch: master
 env:


### PR DESCRIPTION
In Travis CI config linting, it reports `skip_cleanup` as deprecated and
to use `cleanup` instead. But it seems like this doesn't actually work
in dplv1. The success criteria for this commit is that the static site
content will be built in the `gh-pages` branch on the repo.